### PR TITLE
Add function to fetch information about a specific recipe and load it in svelte components

### DIFF
--- a/apps/frontend/src/routes/recipes/[slug]/+page.js
+++ b/apps/frontend/src/routes/recipes/[slug]/+page.js
@@ -1,0 +1,36 @@
+import { PUBLIC_SPOONACULAR_API_KEY } from "$env/static/public";
+
+export const load = ({ params }) => {
+  const recipeId = params.slug;
+
+  /**
+   *
+   * @param {string} recipeId
+   */
+  const handleFetchRecipe = async (recipeId) => {
+    const url = `https://api.spoonacular.com/recipes/${recipeId}/information?apiKey=${PUBLIC_SPOONACULAR_API_KEY}`;
+
+    try {
+      const res = await fetch(url, {
+        method: "Get",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const data = await res.json();
+
+      return data;
+    } catch (err) {
+      return err;
+    }
+  };
+
+  const recipeInfo = handleFetchRecipe(recipeId);
+
+  return {
+    props: {
+      recipeInfo,
+    },
+  };
+};


### PR DESCRIPTION
This commit adds a new file `+page.js` in the `recipes/[slug]` directory of the frontend app. The file contains a function `load` that is responsible for fetching recipe information from the Spoonacular API. The function takes the `slug` parameter and uses it to construct the API URL. It then makes a GET request to the API and returns the fetched data. The fetched recipe information is then passed as a prop to the component.

This change was made to enable the dynamic loading of recipe information on the recipe detail page.
