### PR TITLE
Implement fetching the analyzed recipes instructions and passing them to the recipes page

### DIFF
--- a/apps/frontend/src/routes/recipes/[slug]/+page.js
+++ b/apps/frontend/src/routes/recipes/[slug]/+page.js
@@ -26,11 +26,36 @@ export const load = async ({ params }) => {
     }
   };
 
+  /**
+   *
+   * @param {string} recipeId
+   */
+  const handleFetchInstructions = async (recipeId) => {
+    const url = `https://api.spoonacular.com/recipes/${recipeId}/analyzedInstructions?apiKey=${PUBLIC_SPOONACULAR_API_KEY}`;
+
+    try {
+      const res = await fetch(url, {
+        method: "Get",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const data = await res.json();
+
+      return data;
+    } catch (err) {
+      return err;
+    }
+  };
+
   const recipeInfo = await handleFetchRecipe(recipeId);
+  const instructions = await handleFetchInstructions(recipeId);
 
   return {
     props: {
       ...recipeInfo,
+      instructions,
     },
   };
 };


### PR DESCRIPTION
The changes in this commit add a new function `handleFetchInstructions` that fetches the analyzed instructions for a recipe from the Spoonacular API. The function takes a `recipeId` parameter and constructs the API URL using the provided `PUBLIC_SPOONACULAR_API_KEY`. It then makes a GET request to the API and returns the fetched data.

In the `load` function, the `handleFetchInstructions` function is called with the `recipeId` to fetch the instructions for the recipe. The fetched instructions are included in the `props` object that is returned from the `load` function.

This change improves the functionality of the page by providing the recipe instructions along with other recipe information.
